### PR TITLE
Adding Authentication Headers Support to Authenticating against Services with API Keys

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,11 @@ module.exports = function (grunt) {
                 packaging: 'zip',
                 auth: {
                     username: auth.username,
-                    password: auth.password
+                    password: auth.password,
+                    headers: {
+                        'Authorization': 'Bearer token123',
+                        'Private-Token': 'secret-api-token'
+                    }
                 },
                 pomDir: 'test/actual/releases',
                 url: 'http://localhost:8081/nexus/content/repositories/releases',

--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ Default value: `''`
 
 Username to be used for authentication against nexus server
 
+#### options.auth.headers
+Type: `Object`
+Default value: `{}`
+
+A key-value pair where each will be passed as Http Request Header to authenticate against nexus server.
+E.g. Personal Access Token instead of username/password:
+`{Authorization: 'Bearer secret-token'}`
+
 #### options.insecure
 Type: `boolean`
 Default value: `false`

--- a/tasks/lib/index.js
+++ b/tasks/lib/index.js
@@ -83,8 +83,16 @@ var createAndUploadArtifacts = function (options, done) {
 				curlOptions.push('/dev/stderr');
 			}
             if (options.auth) {
-                curlOptions.push('-u');
-                curlOptions.push('"'+options.auth.username + ":" + options.auth.password+'"');
+                if (options.auth.username && options.auth.password) {
+                    curlOptions.push('-u');
+                    curlOptions.push('"' + options.auth.username + ":" + options.auth.password + '"');
+                }
+                if (options.auth.headers) {
+                    Object.keys(options.auth.headers).map(function (key) {
+                        curlOptions.push('--header');
+                        curlOptions.push('"' + key + ': ' + options.auth.headers[key] + '"');
+                    });
+                }
             }
 
             if (options.insecure) {


### PR DESCRIPTION
Hi,

some Services, like the Gitlab Maven API [1], expect some special Headers instead/in addition to Basic Authentication. In order to support those APIs I added a feature of passing these headers into the web-nexus-deployer config.

Thx for having a look on that PR!

[1] https://docs.gitlab.com/ee/api/packages/maven.html#upload-a-package-file